### PR TITLE
Update .gitignore to include 'bistu/' and add new script for importin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ dmypy.json
 law/
 docker/weaviate_data/
 audit_files/
+bistu/

--- a/src/3_delete_collection.py
+++ b/src/3_delete_collection.py
@@ -19,7 +19,7 @@ client = weaviate.connect_to_custom(
     grpc_host=grpc_host,
     grpc_port=grpc_port,
     grpc_secure=False,
-    auth_credentials=Auth.api_key(weaviate_api_key),
+    # auth_credentials=Auth.api_key(weaviate_api_key),
 )
 
 # if client.collections.exists(name="tiangong"):

--- a/src/5_import_to_weaviate_pkl.py
+++ b/src/5_import_to_weaviate_pkl.py
@@ -1,0 +1,79 @@
+from weaviate.classes.config import Configure, Property, DataType, Tokenization
+from weaviate.classes.init import Auth
+import logging
+import os
+import pickle
+import weaviate
+import uuid
+
+from tools.text_to_weaviate import merge_pickle_list, fix_utf8, split_chunks
+
+logging.basicConfig(
+    filename="weaviate_bistu.log",
+    filemode="w",
+    level=logging.INFO,
+    format="%(asctime)s:%(levelname)s:%(message)s",
+    force=True,
+)
+
+
+http_host = os.environ["WEAVIATE_HTTP_HOST"]
+http_port = os.environ["WEAVIATE_HTTP_PORT"]
+grpc_host = os.environ["WEAVIATE_GRPC_HOST"]
+grpc_port = os.environ["WEAVIATE_GRPC_PORT"]
+
+client = weaviate.connect_to_custom(
+    http_host=http_host,  # Hostname for the HTTP API connection
+    http_port=http_port,  # Default is 80, WCD uses 443
+    http_secure=False,  # Whether to use https (secure) for the HTTP API connection
+    grpc_host=grpc_host,  # Hostname for the gRPC API connection
+    grpc_port=grpc_port,  # Default is 50051, WCD uses 443
+    grpc_secure=False,  # Whether to use a secure channel for the gRPC API connection
+    # auth_credentials=Auth.api_key(weaviate_api_key),  # API key for authentication
+)
+
+def split_chunks(doc_id, text_list, source):
+    chunks = []
+    for index, chunk_text in enumerate(text_list):
+        doc_chunk_id = f"{doc_id}_{index}"
+        chunks.append({
+            "doc_chunk_id": doc_chunk_id,
+            "content": chunk_text,
+            "source": source,
+        })
+    return chunks
+
+collection = client.collections.get(name="bistu")
+
+# Set the root directory for pickle files
+pickle_root = "bistu/pickles/2023"
+
+# Recursively walk through all directories and find pickle files
+for root, _, files in os.walk(pickle_root):
+    for file in files:
+        if file.endswith(".pkl"):
+            pickle_path = os.path.join(root, file)
+            # Calculate the relative path from pickle_root as source
+            relative_path = os.path.splitext(os.path.relpath(pickle_path, pickle_root))[0]
+            
+            # Generate a document ID based on the pickle file
+            doc_id = str(uuid.uuid4())
+            
+            try:
+                with open(pickle_path, "rb") as f:
+                    text_list = pickle.load(f)
+                    text_list = [item for item in text_list if item is not None]
+                    text_list = [item["text"] for item in text_list]
+
+                data = merge_pickle_list(text_list)
+                data = fix_utf8(data)
+                chunks = split_chunks(doc_id, text_list=data, source=relative_path)
+
+            except Exception as e:
+                logging.error(f"Error reading pickle file {pickle_path}: {e}")
+                continue
+
+            collection.data.insert_many(chunks)
+            logging.info(f"Inserted {pickle_path}")
+
+client.close()


### PR DESCRIPTION
@linancn 
This pull request includes changes to improve the handling of Weaviate API connections and introduces a new script for importing data from pickle files into a Weaviate collection. The most important changes include commenting out the authentication credentials in the existing script and adding a new script with extensive functionality for data processing and insertion.

### Changes to Weaviate API connection:

* [`src/3_delete_collection.py`](diffhunk://#diff-ccd61ddb3891d33e1399e9ebb111795cbadd970a320c3eda6a228c6ab7c35c1cL22-R22): Commented out the `auth_credentials` parameter in the Weaviate client connection setup, disabling the use of API key-based authentication.

### New script for importing data:

* `src/5_import_to_weaviate_pkl.py`: Added a new script to process and import data from pickle files into a Weaviate collection. This script includes:
  - Environment variable-based configuration for HTTP and gRPC connections.
  - Logging setup for monitoring the import process.
  - Functions to handle data processing, including splitting text into chunks and fixing UTF-8 encoding issues.
  - Recursive traversal of a directory to find pickle files, process their content, and insert the data into a Weaviate collection.